### PR TITLE
Add lower case support to utility prompt

### DIFF
--- a/src/prompts.ts
+++ b/src/prompts.ts
@@ -1,5 +1,5 @@
 import promptSync from "prompt-sync";
-import * as fs from 'fs';
+import * as fs from "fs";
 const prompt = promptSync({ sigint: true });
 
 import passwordPrompt from "prompts";
@@ -60,8 +60,8 @@ export async function promptForFix(
 	console.log(" - Id: %s", entityId);
 	const answer: string = prompt(
 		"Do you want to fix it?  This will cost ~0.000001 AR (default is No) Y/N "
-	);
-	if (answer === "Y") {
+	).toUpperCase();
+	if (answer === "Y" || answer === "YES") {
 		return true;
 	} else {
 		return false;


### PR DESCRIPTION
Previously typing in "y" would skip fixing the root folder.

This fix supports "y", "yes", "Y", "YES", "Yes", "yEs", etc.